### PR TITLE
Replace AppBar

### DIFF
--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -2,18 +2,17 @@
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 
-<AppBar classes="px-10" trailClasses="space-x-4 items-center">
-	{#snippet lead()}
+<div class="w-full h-full flex flex-row justify-between px-10 items-center">
+	<div>
 		<h2 class="h2 text-success-500">dev.portfolio</h2>
-	{/snippet}
-
-	{#snippet trail()}
+	</div>
+	<div>
 		<a href="#home" class="transition-colors hover:text-success-500">Home</a>
 		<a href="#projects" class="transition-colors hover:text-success-500">Projects</a>
 		<a href="#github" class="transition-colors hover:text-success-500">GitHub</a>
 		<a href="#contact" class="transition-colors hover:text-success-500">Contact</a>
-	{/snippet}
-</AppBar>
+	</div>
+</div>
 
 <style>
 	/* Credit: https://stackoverflow.com/questions/62867788/text-underline-animation-in-css-the-simplest-way */


### PR DESCRIPTION
This pull request refactors the layout of the header component to remove the dependency on the `AppBar` component and implement a custom flexbox layout. The changes improve the clarity and maintainability of the header's structure.

Layout refactor:

* Replaced the usage of the `AppBar` component with a custom `div` that uses flexbox for layout, providing more control over the header's appearance and structure. (`src/lib/components/header.svelte`)
* Removed the use of Svelte snippets (`lead` and `trail`) and directly placed the header title and navigation links inside separate `div` elements for better readability and easier customization. (`src/lib/components/header.svelte`)